### PR TITLE
Support RFC 7464 formatted output

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,19 @@ mapper.
 ## Additional Notes
 - The `mr cooperative` command usually needs to contact the OSM servers when
 generating tasks and thus needs internet access to run. To play nice with OSM
-servers, at most 4 network requests per second will be made.
+servers, at most 4 network requests per second will be made
 
 - Generated challenge files use a
 [line-by-line](https://github.com/osmlab/maproulette3/wiki/Line-by-Line-GeoJSON-Format)
 format that is well suited to streaming, whereby each line in the file contains a
 complete GeoJSON object representing a single task in the challenge. It may not be
 possible to open or manipulate this file using traditional GeoJSON tools
+
+- As of v0.1.1, a `--rfc7464` option can be provided to output line-by-line
+GeoJSON using [RFC 7464](https://tools.ietf.org/html/rfc7464) compliant
+formatting (for use with MapRoulette v3.6.5+ instances). If you are generating
+challenges with just a single task, it is recommended you use this option if
+possible
 
 - This utility has not been tested on Windows
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maproulette/mr-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maproulette/mr-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Generate MapRoulette cooperative challenges from change files",
   "keywords": [
     "maproulette",

--- a/src/commands/cooperative_commands/changes.js
+++ b/src/commands/cooperative_commands/changes.js
@@ -67,6 +67,10 @@ function writeTaskGeoJSON(features, change, format, context) {
     }
   }
 
+  if (context.rfc7464) {
+    // RFC 7464 start of sequence
+    context.out.write(Constants.controlChars.RS, "utf8")
+  }
   context.out.write(JSON.stringify(geoJSON), "utf8")
   context.out.write("\n", "utf8")
 }
@@ -111,7 +115,14 @@ exports.handler = async function(argv) {
   spinner.succeed()
   spinner.start("Generate tasks")
 
-  const context = { out, spinner, bijective: argv.bijective, osmChange: argv.osc, josmChange: argv.josm }
+  const context = {
+    out,
+    spinner,
+    bijective: argv.bijective,
+    osmChange: argv.osc,
+    josmChange: argv.josm,
+    rfc7464: argv.rfc7464,
+  }
   try {
     for (let i = 0; i < argv.inputFiles.length; i++) {
       context.filename = argv.inputFiles[i]

--- a/src/commands/cooperative_commands/tags.js
+++ b/src/commands/cooperative_commands/tags.js
@@ -78,6 +78,10 @@ const generateCooperativeWork = async (context, {changes, elementMaps, elementDa
       cooperativeWork,
     }
 
+    if (context.rfc7464) {
+      // RFC 7464 start of sequence
+      context.out.write(Constants.controlChars.RS, "utf8")
+    }
     context.out.write(JSON.stringify(geoJSON), "utf8")
     context.out.write("\n", "utf8")
   }
@@ -235,7 +239,15 @@ exports.handler = async function(argv) {
     process.exit(1)
   }
 
-  const context = { out, spinner, osmChange: argv.osc, josmChange: argv.josm, skip: argv.skip }
+  const context = {
+    out,
+    spinner,
+    osmChange: argv.osc,
+    josmChange: argv.josm,
+    skip: argv.skip,
+    rfc7464: argv.rfc7464,
+  }
+
   try {
     for (let i = 0; i < argv.inputFiles.length; i++) {
       context.filename = argv.inputFiles[i]

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -34,6 +34,10 @@ const Constants = Object.freeze({
       delete: 'delete',
     }),
   }),
+
+  controlChars: Object.freeze({
+    RS: String.fromCharCode(0x1E), // RS (record separator) control char
+  }),
 })
 
 module.exports = Constants

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,14 @@ const argv =
   .demandCommand()
   .boolean('quiet')
   .alias('quiet', 'silent')
-  .describe('quiet', 'Quiet mode: suppress status messages')
+  .describe(
+    'quiet',
+    'Quiet mode: suppress status messages'
+  )
+  .boolean('rfc7464')
+  .describe(
+    'rfc7464',
+    'Output RFC 7464 compliant format (MapRoulette v3.6.5+)'
+  )
   .wrap(yargs.terminalWidth())
   .argv


### PR DESCRIPTION
* Add new `--rfc7464` option that causes RFC 7464 formatted GeoJSON to
be outputted (for use with MapRoulette v3.6.5+ instances)