### PR TITLE
xmltojson package needs to be lower case to be found

### DIFF
--- a/src/commands/cooperative_commands/tags.js
+++ b/src/commands/cooperative_commands/tags.js
@@ -1,5 +1,5 @@
 const { DOMParser } = require('xmldom')
-const xmlToJSON = require('xmlToJSON')
+const xmlToJSON = require('xmltojson')
 const _fromPairs = require('lodash.frompairs')
 const _isEqual = require('lodash.isequal')
 const _differenceWith = require('lodash.differencewith')

--- a/src/common/josm_file_parser.js
+++ b/src/common/josm_file_parser.js
@@ -1,5 +1,5 @@
 const { DOMParser, XMLSerializer } = require('xmldom')
-const xmlToJSON = require('xmlToJSON')
+const xmlToJSON = require('xmltojson')
 const _fromPairs = require('lodash.frompairs')
 const _find = require('lodash.find')
 const _filter = require('lodash.filter')

--- a/src/common/osc_file_parser.js
+++ b/src/common/osc_file_parser.js
@@ -1,5 +1,5 @@
 const { DOMParser, XMLSerializer } = require('xmldom')
-const xmlToJSON = require('xmlToJSON')
+const xmlToJSON = require('xmltojson')
 const _fromPairs = require('lodash.frompairs')
 const _find = require('lodash.find')
 const _flatten = require('lodash.flatten')

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,5 +1,5 @@
 const { DOMParser, XMLSerializer } = require('xmldom')
-const xmlToJSON = require('xmlToJSON')
+const xmlToJSON = require('xmltojson')
 const turf = require('@turf/turf')
 const fetch = require('node-fetch')
 const _isPlainObject = require('lodash.isplainobject')


### PR DESCRIPTION
When I tried to run the latest release I got `Error: Cannot find module 'xmlToJSON'` so seems the package name is case sensitive.